### PR TITLE
Add a uninstall script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -59,8 +59,9 @@ while getopts "mg" option; do
               wget "https://go.dev/dl/go1.19.linux-amd64.tar.gz"
               sudo tar -C /usr/local -xzf go1.19.linux-amd64.tar.gz
               rm go1.19.linux-amd64.tar.gz
-              echo "PATH=$PATH:/usr/local/go/bin" >> ~/.profile
-              source ~/.profile
+              read -p "GoLang needs to be manually added to the path please enter the file that your terminal sources for login sessions (~/.bash_profile, ~/.zprofile, etc): " prof
+              echo "PATH=$PATH:/usr/local/go/bin" >> "$prof"
+              source "$prof"
            ;;
         ?)
             break

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,46 @@
+for arg in "$@"; do
+  shift
+  case ${arg} in
+    "-mongo6") set -- "$@" "-m" ;;
+    "-mongo4") set -- "$@" "-z" ;;
+    "-go") set -- "$@" "-g" ;;
+    *)        set -- "$@" "$arg"
+  esac
+done
+
+while getopts "mg" option; do
+    case ${option} in
+        m)
+                echo "Unisntalling Mongo 6.0 Repository\n"
+                sudo apt purge mongodb-org
+                read -p "Do you wish to remove the MongoDB keys and repos? (y/n): " answer
+                if [ "$answer" == "y" ]; then
+                echo "Removing List Entry\n"
+                sudo rm /etc/apt/sources.list.d/mongodb-org-6.0.list
+                echo "Removing mongodb keys\n"
+                sudo rm /usr/share/keyrings/server-6.0.gpg
+                fi
+                echo "MongoDB has successfully been uninstalled.\n"
+            ;;
+        z)
+                echo "Unisntalling Mongo 4.4 Repository\n"
+                sudo apt purge mongodb-org
+                read -p "Do you wish to remove the MongoDB keys and repos? (y/n): " answer
+                if [ "$answer" == "y" ]; then
+                echo "Removing List Entry\n"
+                sudo rm /etc/apt/sources.list.d/mongodb-org-4.4.list
+                echo "Removing mongodb keys\n"
+                sudo rm /usr/share/keyrings/server-4.4.gpg
+                fi
+                echo "MongoDB has successfully been uninstalled.\n"
+            ;;
+        g)
+              echo "Removing local go bin.\n"
+              rm -rf /usr/local/go
+              echo "Note this does not remove the entry to your path.\n"
+           ;;
+        ?)
+            break
+            ;;
+    esac
+done


### PR DESCRIPTION
A small uninstall script so that users can remove said packages without having to look all over for uninstall methods. Note this doesn't delete mongodb data directories.